### PR TITLE
Pin Docker base image to senzingapi-runtime:3.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # docker build -t brian/sz_incremental_withinfo .
 # docker run --user $UID -it -v $PWD:/data -e SENZING_ENGINE_CONFIGURATION_JSON brian/sz_incremental_withinfo -o /data/delta.json -i /data/tmpinfo.json /dev/null
 
-ARG BASE_IMAGE=senzing/senzingapi-runtime:staging
+ARG BASE_IMAGE=senzing/senzingapi-runtime:3.13.1
 FROM ${BASE_IMAGE}
 
 ENV REFRESHED_AT=2022-08-27


### PR DESCRIPTION
## Pin Docker base image to a concrete version

Replaces the moving `:staging` pre-release tag with a concrete, immutable released version so builds are reproducible.

- Image family unchanged (v3 `senzing/senzingapi-runtime` — this is a v3 repo).
- Pinned to `3.13.1`, the newest released v3 version (also what `:latest` currently resolves to). Note: `:staging` was a moving pre-release tag and may have pointed at an unreleased build; `3.13.1` is the newest stable release chosen as the concrete pin.